### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/archives/2023/2023-08-22/19cd4a4c69bc1f79c515f242eb7ce3b3.md
+++ b/archives/2023/2023-08-22/19cd4a4c69bc1f79c515f242eb7ce3b3.md
@@ -1,3 +1,3 @@
 # [Published on 2023-08-22](index.md)
 
-* [2023-08-22, 03:24:45](https://news.ycombinator.com/item?id=37218289) - [NixOS Impermanence](https://nixos.wiki/wiki/Impermanence)
+* [2023-08-22, 03:24:45](https://news.ycombinator.com/item?id=37218289) - [NixOS Impermanence](https://wiki.nixos.org/wiki/Impermanence)

--- a/archives/2023/2023-08-22/index.md
+++ b/archives/2023/2023-08-22/index.md
@@ -107,7 +107,7 @@
 * [2023-08-22, 04:34:04](https://news.ycombinator.com/item?id=37218727) - [Revolutionary Electrolyzer Efficiently Converts CO2 into Renewable Propane Fuel](https://scienceswitch.com/2023/08/22/revolutionary-electrolyzer-efficiently-converts-co2-into-renewable-propane-fuel/)
 * [2023-08-22, 04:00:29](https://news.ycombinator.com/item?id=37218531) - [Charging capacitors from thermal fluctuations using diodes](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.108.024130)
 * [2023-08-22, 03:58:21](https://news.ycombinator.com/item?id=37218517) - [The Antidesktop (2002)](http://web.archive.org/web/20021201230839/http://palm.freshmeat.net/articles/view/581/)
-* [2023-08-22, 03:24:45](https://news.ycombinator.com/item?id=37218289) - [NixOS Impermanence](https://nixos.wiki/wiki/Impermanence)
+* [2023-08-22, 03:24:45](https://news.ycombinator.com/item?id=37218289) - [NixOS Impermanence](https://wiki.nixos.org/wiki/Impermanence)
 * [2023-08-22, 03:21:56](https://news.ycombinator.com/item?id=37218268) - [Asphalt Wasteland: Maybe parking does explain the world](https://www.commonwealmagazine.org/parking-grabar-slate-henry-paved-paradise)
 * [2023-08-22, 03:20:32](https://news.ycombinator.com/item?id=37218263) - [Learn AutoHotKey by stealing my scripts](https://www.hillelwayne.com/post/ahk-scripts-project/)
 * [2023-08-22, 02:58:43](https://news.ycombinator.com/item?id=37218114) - [Unlocking Discord Nitro Features for Free](https://blog.0x7d0.dev/history/unlocking-discord-nitro-features-for-free/)

--- a/archives/2024/2024-02-07/522cab3959e55fc5dafb8633317b0220.md
+++ b/archives/2024/2024-02-07/522cab3959e55fc5dafb8633317b0220.md
@@ -1,3 +1,3 @@
 # [Published on 2024-02-07](index.md)
 
-* [2024-02-07, 19:23:01](https://news.ycombinator.com/item?id=39292985) - [Nix-shell shebang: run any script with arbitrary packages, self-contained](https://nixos.wiki/wiki/Nix-shell_shebang)
+* [2024-02-07, 19:23:01](https://news.ycombinator.com/item?id=39292985) - [Nix-shell shebang: run any script with arbitrary packages, self-contained](https://wiki.nixos.org/wiki/Nix-shell_shebang)

--- a/archives/2024/2024-02-07/index.md
+++ b/archives/2024/2024-02-07/index.md
@@ -32,7 +32,7 @@
 * [2024-02-07, 19:31:13](https://news.ycombinator.com/item?id=39293093) - [JavaScript in SVGs](https://www.devdailydigest.tech/javascript-in-svgs/)
 * [2024-02-07, 19:28:05](https://news.ycombinator.com/item?id=39293050) - [A search engine in 80 lines of Python](https://www.alexmolas.com/2024/02/05/a-search-engine-in-80-lines.html)
 * [2024-02-07, 19:23:21](https://news.ycombinator.com/item?id=39292990) - [Beyond the 1 MB barrier in DOS](https://blogsystem5.substack.com/p/beyond-the-1-mb-barrier-in-dos)
-* [2024-02-07, 19:23:01](https://news.ycombinator.com/item?id=39292985) - [Nix-shell shebang: run any script with arbitrary packages, self-contained](https://nixos.wiki/wiki/Nix-shell_shebang)
+* [2024-02-07, 19:23:01](https://news.ycombinator.com/item?id=39292985) - [Nix-shell shebang: run any script with arbitrary packages, self-contained](https://wiki.nixos.org/wiki/Nix-shell_shebang)
 * [2024-02-07, 19:19:02](https://news.ycombinator.com/item?id=39292941) - [A record number of Americans can't afford rent](https://apnews.com/article/affordable-housing-rent-eviction-price-harvard-congress-f5411012e10fa78d0257c137e60c1be3)
 * [2024-02-07, 19:18:14](https://news.ycombinator.com/item?id=39292929) - [Lawsuit Accuses Anna's Archive of Hacking WorldCat, Stealing 2.2 TB Data](https://torrentfreak.com/lawsuit-accuses-annas-archive-of-hacking-worldcat-stealing-2-2-tb-data-240207/)
 * [2024-02-07, 18:59:10](https://news.ycombinator.com/item?id=39292690) - [Neanderthals, modern humans may have co-existed in Europe for at least 10k years](https://theconversation.com/how-long-did-neanderthals-and-modern-humans-co-exist-in-europe-evidence-is-growing-it-may-have-been-at-least-10-000-years-222762)


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️